### PR TITLE
fix(EditRecordingModal): prevent audio rerendered

### DIFF
--- a/apps/whispering/src/routes/(config)/recordings/row-actions/EditRecordingModal.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/EditRecordingModal.svelte
@@ -70,8 +70,8 @@
 	const blobUrlManager = createBlobUrlManager();
 
 	const blobUrl = $derived.by(() => {
-		if (!workingCopy?.blob) return undefined;
-		return blobUrlManager.createUrl(workingCopy.blob);
+		if (!recording?.blob) return undefined;
+		return blobUrlManager.createUrl(recording.blob);
 	});
 
 	function promptUserConfirmLeave() {


### PR DESCRIPTION
 This fixes the audio player rerendering
  every time users type in the edit
  recording modal input fields. Previously,
   typing in the title, subtitle, or other
  text fields would cause the audio player
  to reload and reset its playback
  position, creating a poor user
  experience.

  The issue occurred because the audio
  player's `src` was derived from
  `workingCopy.blob`, but `workingCopy`
  gets updated on every keystroke. Since
  the audio blob itself never changes
  during editing (users are only modifying
  metadata), the audio player was
  unnecessarily rerendering.

before: 

https://github.com/user-attachments/assets/2ef9e4b7-7e2a-4df2-9550-50a765106207


after: 


https://github.com/user-attachments/assets/cd0cdcb9-9da5-45d1-89eb-5d6fc8492e61

