### PR TITLE
refactor: migrate oninput handlers to function bindings and bind:value

### DIFF
--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -136,10 +136,10 @@
 		<LabeledInput
 			id="compression-options-{Math.random().toString(36).substr(2, 9)}"
 			label="Custom Options"
-			value={settings.value['transcription.compressionOptions']}
-			oninput={({ currentTarget: { value } }) => {
-				settings.updateKey('transcription.compressionOptions', value);
-			}}
+			bind:value={
+				() => settings.value['transcription.compressionOptions'],
+				(value) => settings.updateKey('transcription.compressionOptions', value)
+			}
 			placeholder={FFMPEG_DEFAULT_COMPRESSION_OPTIONS}
 			description="FFmpeg compression options. Changes here will be reflected in real-time during transcription."
 		>

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/AnthropicApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/AnthropicApiKeyInput.svelte
@@ -9,10 +9,10 @@
 	label="Anthropic API Key"
 	type="password"
 	placeholder="Your Anthropic API Key"
-	value={settings.value['apiKeys.anthropic']}
-	oninput={({ currentTarget: { value } }) => {
-		settings.updateKey('apiKeys.anthropic', value);
-	}}
+	bind:value={
+		() => settings.value['apiKeys.anthropic'],
+		(value) => settings.updateKey('apiKeys.anthropic', value)
+	}
 >
 	{#snippet description()}
 		<p class="text-muted-foreground text-sm">

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/DeepgramApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/DeepgramApiKeyInput.svelte
@@ -9,10 +9,10 @@
     label="Deepgram API Key"
     type="password"
     placeholder="Your Deepgram API Key"
-    value={settings.value['apiKeys.deepgram']}
-    oninput={({ currentTarget: { value } }) => {
-        settings.updateKey('apiKeys.deepgram', value);
-    }}
+    bind:value={
+        () => settings.value['apiKeys.deepgram'],
+        (value) => settings.updateKey('apiKeys.deepgram', value)
+    }
 >
     {#snippet description()}
         <p class="text-muted-foreground text-sm">

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/ElevenLabsApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/ElevenLabsApiKeyInput.svelte
@@ -9,10 +9,10 @@
 	label="ElevenLabs API Key"
 	type="password"
 	placeholder="Your ElevenLabs API Key"
-	value={settings.value['apiKeys.elevenlabs']}
-	oninput={({ currentTarget: { value } }) => {
-		settings.updateKey('apiKeys.elevenlabs', value);
-	}}
+	bind:value={
+		() => settings.value['apiKeys.elevenlabs'],
+		(value) => settings.updateKey('apiKeys.elevenlabs', value)
+	}
 >
 	{#snippet description()}
 		<p class="text-muted-foreground text-sm">

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/GoogleApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/GoogleApiKeyInput.svelte
@@ -9,10 +9,10 @@
 	label="Google API Key"
 	type="password"
 	placeholder="Your Google API Key"
-	value={settings.value['apiKeys.google']}
-	oninput={({ currentTarget: { value } }) => {
-		settings.updateKey('apiKeys.google', value);
-	}}
+	bind:value={
+		() => settings.value['apiKeys.google'],
+		(value) => settings.updateKey('apiKeys.google', value)
+	}
 >
 	{#snippet description()}
 		<p class="text-muted-foreground text-sm">

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/GroqApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/GroqApiKeyInput.svelte
@@ -9,10 +9,10 @@
 	label="Groq API Key"
 	type="password"
 	placeholder="Your Groq API Key"
-	value={settings.value['apiKeys.groq']}
-	oninput={({ currentTarget: { value } }) => {
-		settings.updateKey('apiKeys.groq', value);
-	}}
+	bind:value={
+		() => settings.value['apiKeys.groq'],
+		(value) => settings.updateKey('apiKeys.groq', value)
+	}
 >
 	{#snippet description()}
 		<p class="text-muted-foreground text-sm">

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/OpenAiApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/OpenAiApiKeyInput.svelte
@@ -9,10 +9,10 @@
 	label="OpenAI API Key"
 	type="password"
 	placeholder="Your OpenAI API Key"
-	value={settings.value['apiKeys.openai']}
-	oninput={({ currentTarget: { value } }) => {
-		settings.updateKey('apiKeys.openai', value);
-	}}
+	bind:value={
+		() => settings.value['apiKeys.openai'],
+		(value) => settings.updateKey('apiKeys.openai', value)
+	}
 >
 	{#snippet description()}
 		<p class="text-muted-foreground text-sm">

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/OpenRouterApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/OpenRouterApiKeyInput.svelte
@@ -9,10 +9,10 @@
 	label="OpenRouter API Key"
 	type="password"
 	placeholder="Your OpenRouter API Key"
-	value={settings.value['apiKeys.openrouter']}
-	oninput={({ currentTarget: { value } }) => {
-		settings.updateKey('apiKeys.openrouter', value);
-	}}
+	bind:value={
+		() => settings.value['apiKeys.openrouter'],
+		(value) => settings.updateKey('apiKeys.openrouter', value)
+	}
 >
 	{#snippet description()}
 		<p class="text-muted-foreground text-sm">

--- a/apps/whispering/src/routes/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/+page.svelte
@@ -374,8 +374,7 @@
 				placeholder="Filter transcripts..."
 				type="text"
 				class="w-full md:max-w-sm"
-				value={globalFilter}
-				oninput={(e) => (globalFilter = e.currentTarget.value)}
+				bind:value={globalFilter}
 			/>
 			<div class="flex w-full items-center justify-between gap-2">
 				{#if selectedRecordingRows.length > 0}

--- a/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
@@ -274,10 +274,10 @@
 			id="speaches-base-url"
 			label="Base URL"
 			placeholder="http://localhost:8000"
-			value={settings.value['transcription.speaches.baseUrl']}
-			oninput={({ currentTarget: { value } }) => {
-				settings.updateKey('transcription.speaches.baseUrl', value);
-			}}
+			bind:value={
+				() => settings.value['transcription.speaches.baseUrl'],
+				(value) => settings.updateKey('transcription.speaches.baseUrl', value)
+			}
 		>
 			{#snippet description()}
 				<p class="text-muted-foreground text-sm">
@@ -305,10 +305,10 @@
 			id="speaches-model-id"
 			label="Model ID"
 			placeholder="Systran/faster-distil-whisper-small.en"
-			value={settings.value['transcription.speaches.modelId']}
-			oninput={({ currentTarget: { value } }) => {
-				settings.updateKey('transcription.speaches.modelId', value);
-			}}
+			bind:value={
+				() => settings.value['transcription.speaches.modelId'],
+				(value) => settings.updateKey('transcription.speaches.modelId', value)
+			}
 		>
 			{#snippet description()}
 				<p class="text-muted-foreground text-sm">
@@ -389,10 +389,10 @@
 		max="1"
 		step="0.1"
 		placeholder="0"
-		value={settings.value['transcription.temperature']}
-		oninput={({ currentTarget: { value } }) => {
-			settings.updateKey('transcription.temperature', value);
-		}}
+		bind:value={
+			() => settings.value['transcription.temperature'],
+			(value) => settings.updateKey('transcription.temperature', value)
+		}
 		description="Controls randomness in the model's output. 0 is focused and deterministic, 1 is more creative."
 	/>
 
@@ -400,10 +400,10 @@
 		id="transcription-prompt"
 		label="System Prompt"
 		placeholder="e.g., This is an academic lecture about quantum physics with technical terms like 'eigenvalue' and 'Schrödinger'"
-		value={settings.value['transcription.prompt']}
-		oninput={({ currentTarget: { value } }) => {
-			settings.updateKey('transcription.prompt', value);
-		}}
+		bind:value={
+			() => settings.value['transcription.prompt'],
+			(value) => settings.updateKey('transcription.prompt', value)
+		}
 		description="Helps transcription service (e.g., Whisper) better recognize specific terms, names, or context during initial transcription. Not for text transformations - use the Transformations tab for post-processing rules."
 	/>
 </div>

--- a/apps/whispering/src/routes/(config)/transformations/+page.svelte
+++ b/apps/whispering/src/routes/(config)/transformations/+page.svelte
@@ -119,6 +119,7 @@
 		schema: z.record(z.string(), z.boolean()),
 	});
 	let pagination = $state<PaginationState>({ pageIndex: 0, pageSize: 10 });
+	let globalFilter = $state('');
 
 	const table = createSvelteTable({
 		getRowId: (originalRow) => originalRow.id,
@@ -158,6 +159,13 @@
 				pagination = updater;
 			}
 		},
+		onGlobalFilterChange: (updater) => {
+			if (typeof updater === 'function') {
+				globalFilter = updater(globalFilter);
+			} else {
+				globalFilter = updater;
+			}
+		},
 		state: {
 			get sorting() {
 				return sorting.value;
@@ -171,21 +179,15 @@
 			get pagination() {
 				return pagination;
 			},
+			get globalFilter() {
+				return globalFilter;
+			},
 		},
 	});
 
 	const selectedTransformationRows = $derived(
 		table.getFilteredSelectedRowModel().rows,
 	);
-
-	const filterQuery = {
-		get value() {
-			return table.getColumn('select')?.getFilterValue() as string;
-		},
-		set value(value) {
-			table.getColumn('select')?.setFilterValue(value);
-		},
-	};
 </script>
 
 <svelte:head>
@@ -205,8 +207,7 @@
 			placeholder="Filter transformations..."
 			type="text"
 			class="w-full"
-			value={filterQuery.value}
-			oninput={(e) => (filterQuery.value = e.currentTarget.value)}
+			bind:value={globalFilter}
 		/>
 		{#if selectedTransformationRows.length > 0}
 			<WhisperingButton
@@ -299,7 +300,7 @@
 				{:else}
 					<Table.Row>
 						<Table.Cell colspan={columns.length} class="h-24 text-center">
-							{#if filterQuery.value}
+							{#if globalFilter}
 								No transformations found.
 							{:else}
 								No transformations yet. Click "Create Transformation" to add


### PR DESCRIPTION
Converts oninput handlers to more idiomatic binding patterns:
- Settings inputs: Use function bindings with getter/setter pattern
- Simple state: Use bind:value for direct binding
Benefits:
- Eliminates boilerplate event handling code
- Provides better type safety and IDE support
- Consistent with Svelte 5 binding patterns
- More declarative approach to two-way binding

Changes:
- All API key inputs: value + oninput → bind:value with function bindings
- Transcription settings: speaches URL, model ID, temperature, prompt
- Compression settings: custom options input
- Filter inputs: globalFilter and filterQuery use simple bind:value

Builds on #752 