### PR TITLE
Fix(docs): point docs to our docs and server

### DIFF
--- a/apps/epicenter/README.md
+++ b/apps/epicenter/README.md
@@ -29,9 +29,9 @@ Any static assets, like images, can be placed in the `public/` directory.
 
 All commands are run from the root of the project, from a terminal:
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `bun install`             | Installs dependencies                            |
+| Command               | Action                                           |
+| :-------------------- | :----------------------------------------------- |
+| `bun install`         | Installs dependencies                            |
 | `bun dev`             | Starts local dev server at `localhost:4321`      |
 | `bun build`           | Build your production site to `./dist/`          |
 | `bun preview`         | Preview your build locally, before deploying     |
@@ -40,4 +40,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## 👀 Want to learn more?
 
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+Feel free to check [our documentation](../../docs/) or jump into our [Discord server](https://go.epicenter.so/discord).


### PR DESCRIPTION
Previously, we were pointing to Astro documentation in both of the `docs` and `discord` links in the PR, fixed it by pointing it to the correct documentation. 